### PR TITLE
kiwi: remove qcom dependencies

### DIFF
--- a/omni.dependencies
+++ b/omni.dependencies
@@ -1,9 +1,0 @@
-
-[
-  {
-    "remote":"github",
-    "repository": "TeamWin/android_device_qcom_common",
-    "target_path": "device/qcom/common",
-    "revision":"android-8.0"
-  }
-]


### PR DESCRIPTION
10/155] including device/qcom/common/Android.mk ...
build/make/core/base_rules.mk:260: error: device/qcom/common/cryptfs_hw: MODULE.TARGET.SHARED_LIBRARIES.libcryptfs_hw already defined by vendor/qcom/opensource/commonsys/cryptfs_hw.