### PR TITLE
kiwi: build libcryptfs_hw from source

### DIFF
--- a/full_kiwi.mk
+++ b/full_kiwi.mk
@@ -25,6 +25,10 @@ PRODUCT_RELEASE_NAME := kiwi
 PRODUCT_AAPT_CONFIG := normal
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
+# Encryption
+PRODUCT_PACKAGES += \
+    libcryptfs_hw
+    
 # Boot animation
 TARGET_SCREEN_HEIGHT := 1920
 TARGET_SCREEN_WIDTH := 1080


### PR DESCRIPTION
ninja: error: '/home/builder/pitchblack/work/out/target/product/kiwi/system/vendor/lib64/libcryptfs_hw.so', needed by '/home/builder/pitchblack/work/out/target/product/kiwi/obj_arm/SHARED_LIBRARIES/libbmlutils_intermediates/teamwin', missing and no known rule to make it
0